### PR TITLE
fix: Windows path resolution using fileURLToPath

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -2,6 +2,7 @@
 import { Command } from "commander";
 import { spawn } from "child_process";
 import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
 import { existsSync } from "fs";
 import pkg from "../package.json";
 
@@ -42,7 +43,7 @@ program
     console.log("Press Ctrl+C to stop\n");
 
     // Find the webapp directory
-    const scriptDir = dirname(import.meta.url.replace("file://", ""));
+    const scriptDir = dirname(fileURLToPath(import.meta.url));
 
     // Check for standalone build first (production)
     const standaloneDir = resolve(scriptDir, "..", ".next", "standalone");

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -3,6 +3,7 @@ import { cors } from "hono/cors";
 import { serveStatic } from "hono/bun";
 import { existsSync } from "fs";
 import { resolve, dirname } from "path";
+import { fileURLToPath } from "url";
 
 import tasksRoutes from "./routes/tasks";
 import epicsRoutes from "./routes/epics";
@@ -42,7 +43,7 @@ app.route("/api/bulk-archive-completed", archiveRoutes);
 app.onError(errorHandler);
 
 // Serve static files in production
-const scriptDir = dirname(import.meta.url.replace("file://", ""));
+const scriptDir = dirname(fileURLToPath(import.meta.url));
 const distClientPath = resolve(scriptDir, "../../dist/client");
 
 if (existsSync(distClientPath)) {


### PR DESCRIPTION
## Summary

- Replaces `import.meta.url.replace("file://", "")` with `fileURLToPath(import.meta.url)` in `src/server/index.ts` and `src/cli.ts`
- On Windows, `import.meta.url` is `file:///C:/Users/...` — the naive replace leaves `/C:/Users/...` which is invalid
- `fileURLToPath` from Node's `url` module handles this correctly on all platforms

Closes #1

## Test plan

- [ ] Verify dashboard starts correctly on Windows
- [ ] Verify dashboard still works on macOS/Linux (no regression)